### PR TITLE
README: fix website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and provides the following features:
 2. Content is retrieved dynamically directly from the specs and you don't need to rebuild.
 3. Adding new pages comes down to adding metadata for the pages you want.
 
-![View the specs!](https://opencontainers.github.io/specs.opencontainers.org/)
+[View the specs!](https://specs.opencontainers.org/)
 
 ## Usage
 


### PR DESCRIPTION
Hello,

the README link to the website seems to be broken. I am not sure if there used to be some image.

I changed it to the direct URL.